### PR TITLE
♻️ Introduce element selectors for tests

### DIFF
--- a/lib/freedom_account_web/components/core_components.ex
+++ b/lib/freedom_account_web/components/core_components.ex
@@ -416,7 +416,7 @@ defmodule FreedomAccountWeb.CoreComponents do
 
   def error(assigns) do
     ~H"""
-    <p class="mt-3 flex gap-3 text-sm leading-6 text-rose-600 phx-no-feedback:hidden">
+    <p class="mt-3 flex gap-3 text-sm leading-6 text-rose-600 phx-no-feedback:hidden" name="error">
       <.icon name="hero-exclamation-circle-mini" class="mt-0.5 h-5 w-5 flex-none" />
       <%= render_slot(@inner_block) %>
     </p>

--- a/test/freedom_account_web/live/account_live_test.exs
+++ b/test/freedom_account_web/live/account_live_test.exs
@@ -17,8 +17,8 @@ defmodule FreedomAccountWeb.AccountLiveTest do
     test "displays account", %{conn: conn, account: account} do
       conn
       |> visit(~p"/")
-      |> assert_has("h1", text: "Freedom Account")
-      |> assert_has("h2", text: escaped(account.name))
+      |> assert_has(title(), text: "Freedom Account")
+      |> assert_has(heading(), text: account.name)
     end
 
     test "updates account within modal", %{conn: conn} do
@@ -27,13 +27,14 @@ defmodule FreedomAccountWeb.AccountLiveTest do
       conn
       |> visit(~p"/")
       |> click_link("Edit")
-      |> assert_has("h2", text: "Settings")
+      |> assert_has(heading(), text: "Settings")
       |> fill_form("#account-form", account: @invalid_attrs)
-      |> assert_has("p", text: "can't be blank")
+      |> assert_has(field_error("#account_name"), text: "can't be blank")
+      |> assert_has(field_error("#account_deposits_per_year"), text: "can't be blank")
       |> fill_form("#account-form", account: update_attrs)
       |> click_button("Save Account")
-      |> assert_has("p", text: "Account updated successfully")
-      |> assert_has("h2", text: escaped(update_attrs[:name]))
+      |> assert_has(flash(:info), text: "Account updated successfully")
+      |> assert_has(heading(), text: escaped(update_attrs[:name]))
     end
   end
 end

--- a/test/freedom_account_web/live/fund_live_test.exs
+++ b/test/freedom_account_web/live/fund_live_test.exs
@@ -19,15 +19,15 @@ defmodule FreedomAccountWeb.FundLiveTest do
 
       conn
       |> visit(~p"/")
-      |> assert_has("h2", text: "Funds")
-      |> assert_has("span", text: fund.icon)
-      |> assert_has("span", text: escaped(fund.name))
+      |> assert_has(heading(), text: "Funds")
+      |> assert_has(table_cell(), text: fund.icon)
+      |> assert_has(table_cell(), text: escaped(fund.name))
     end
 
     test "shows prompt when list is empty", %{conn: conn} do
       conn
       |> visit(~p"/")
-      |> assert_has("h2", text: "Funds")
+      |> assert_has(heading(), text: "Funds")
       |> assert_has("#no-funds", text: "This account has no funds yet. Use the Add Fund button to add one.")
     end
 
@@ -37,14 +37,15 @@ defmodule FreedomAccountWeb.FundLiveTest do
       conn
       |> visit(~p"/")
       |> click_link("Add Fund")
-      |> assert_has("h2", text: "Add Fund")
+      |> assert_has(heading(), text: "Add Fund")
       |> fill_form("#fund-form", fund: @invalid_attrs)
-      |> assert_has("p", text: "can't be blank")
+      |> assert_has(field_error("#fund_icon"), text: "can't be blank")
+      |> assert_has(field_error("#fund_name"), text: "can't be blank")
       |> fill_form("#fund-form", fund: attrs)
       |> click_button("Save Fund")
-      |> assert_has("p", text: "Fund created successfully")
-      |> assert_has("span", text: attrs[:icon])
-      |> assert_has("span", text: escaped(attrs[:name]))
+      |> assert_has(flash(:info), text: "Fund created successfully")
+      |> assert_has(table_cell(), text: attrs[:icon])
+      |> assert_has(table_cell(), text: escaped(attrs[:name]))
     end
 
     #   test "updates fund in listing", %{conn: conn, fund: fund} do

--- a/test/support/element_selectors.ex
+++ b/test/support/element_selectors.ex
@@ -1,0 +1,20 @@
+defmodule FreedomAccountWeb.ElementSelectors do
+  @moduledoc false
+
+  @type selector :: String.t()
+
+  @spec field_error(selector()) :: selector()
+  def field_error(selector), do: "#{selector} ~ [name='error']"
+
+  @spec flash(atom()) :: selector()
+  def flash(level), do: "#flash-#{level}"
+
+  @spec heading :: selector()
+  def heading, do: "h2"
+
+  @spec table_cell :: selector()
+  def table_cell, do: "td"
+
+  @spec title :: selector()
+  def title, do: "h1"
+end

--- a/test/support/feature_case.ex
+++ b/test/support/feature_case.ex
@@ -23,6 +23,7 @@ defmodule FreedomAccountWeb.FeatureCase do
     quote do
       use FreedomAccountWeb, :verified_routes
 
+      import FreedomAccountWeb.ElementSelectors
       import PhoenixTest
       import unquote(__MODULE__)
     end


### PR DESCRIPTION
Allows tests to use more semantic names for finding things on the page without coupling to exact markup.
